### PR TITLE
Update workflow platform configuration

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 env:
   REGISTRY: quay.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: quay.io

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,12 +16,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -49,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
When using the matrix strategy to define the arches to build and push the image only one arch is being retained on Quay. It seems the second build always overwrites the first build, leaving only one arch on Quay. This change puts both arches into the same build step to prevent this happening.